### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/cacerts/v1alpha1/register.go
+++ b/apis/cacerts/v1alpha1/register.go
@@ -53,12 +53,14 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&CAProviderClass{},
 		&CAProviderClassList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/csi-common/driver.go
+++ b/pkg/csi-common/driver.go
@@ -76,7 +76,7 @@ func (d *CSIDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapa
 }
 
 func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceCapability_RPC_Type) {
-	var csc []*csi.ControllerServiceCapability
+	csc := make([]*csi.ControllerServiceCapability, 0, len(cl))
 
 	for _, c := range cl {
 		klog.Infof("Enabling controller service capability: %v", c.String())
@@ -87,7 +87,7 @@ func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceC
 }
 
 func (d *CSIDriver) AddVolumeCapabilityAccessModes(vc []csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability_AccessMode {
-	var vca []*csi.VolumeCapability_AccessMode
+	vca := make([]*csi.VolumeCapability_AccessMode, 0, len(vc))
 	for _, c := range vc {
 		klog.Infof("Enabling volume access mode: %v", c.String())
 		vca = append(vca, NewVolumeCapabilityAccessMode(c))

--- a/pkg/csi-common/driver_test.go
+++ b/pkg/csi-common/driver_test.go
@@ -79,7 +79,8 @@ func TestValidateControllerServiceRequest(t *testing.T) {
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
-		})
+		},
+	)
 
 	// Test controller service publish/unpublish is supported
 	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -406,7 +406,8 @@ func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]b
 			vbundle.CAChain,
 			vbundle.IssuingCA,
 			vbundle.Certificate,
-		), "\n")))
+		), "\n"),
+	))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse certificate chain from vault: %w", err)
 	}

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -239,7 +239,8 @@ func TestSign(t *testing.T) {
 
 		"a good csr but failed request should error": {
 			csrPEM: csrPEM,
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{}),
 			),
 			fakeClient:   vaultfake.NewFakeClient().WithRawRequest(nil, errors.New("request failed")),
@@ -250,7 +251,8 @@ func TestSign(t *testing.T) {
 
 		"a good csr and good response with no root should return a certificate with the intermediate in the chain and as the CA": {
 			csrPEM: csrPEM,
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{}),
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
@@ -265,7 +267,8 @@ func TestSign(t *testing.T) {
 
 		"a good csr and good response with a root should return a certificate without the root in the chain but with the root as the CA": {
 			csrPEM: csrPEM,
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{}),
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
@@ -280,7 +283,8 @@ func TestSign(t *testing.T) {
 
 		"vault issuer with namespace specified": {
 			csrPEM: csrPEM,
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{Namespace: "test"}),
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
@@ -403,7 +407,8 @@ func TestSetToken(t *testing.T) {
 	}
 	tests := map[string]testSetTokenT{
 		"if neither token secret ref, app role secret ref, or kube auth then not found then error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth:     cmapi.VaultAuth{},
@@ -418,7 +423,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if token secret ref is set but secret doesn't exist should error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -437,7 +443,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if token secret ref set, return client using token stored": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -457,7 +464,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if app role set but secret token not but vault fails to return token, error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -480,7 +488,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if app role secret ref set, return client using token stored": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -501,7 +510,8 @@ func TestSetToken(t *testing.T) {
 				Response: &http.Response{
 					Body: io.NopCloser(
 						strings.NewReader(
-							`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-roleapp-token"}}`),
+							`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-roleapp-token"}}`,
+						),
 					),
 				},
 			}, nil),
@@ -510,7 +520,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if kubernetes role auth set but reference secret doesn't exist return error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -533,7 +544,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if kubernetes role auth set but reference secret doesn't contain data at key error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -556,7 +568,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if kubernetes role auth set but errors with a raw request should error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -579,7 +592,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"foo": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -600,7 +614,8 @@ func TestSetToken(t *testing.T) {
 				Response: &http.Response{
 					Body: io.NopCloser(
 						strings.NewReader(
-							`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"}}`),
+							`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"}}`,
+						),
 					),
 				},
 			}, nil),
@@ -609,7 +624,8 @@ func TestSetToken(t *testing.T) {
 		},
 
 		"if app role secret ref and token secret set, take preference on token secret": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 					Auth: cmapi.VaultAuth{
@@ -856,7 +872,8 @@ type testNewConfigT struct {
 func TestNewConfig(t *testing.T) {
 	tests := map[string]testNewConfigT{
 		"no CA bundle set in issuer should return nil": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: nil,
 				}),
@@ -865,7 +882,8 @@ func TestNewConfig(t *testing.T) {
 		},
 
 		"a bad cert bundle should error": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte("a bad cert bundle"),
 				}),
@@ -874,7 +892,8 @@ func TestNewConfig(t *testing.T) {
 		},
 
 		"a good cert bundle should be added to the config": {
-			issuer: gen.Issuer("vault-issuer",
+			issuer: gen.Issuer(
+				"vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{
 					CABundle: []byte(testLeafCertificate),
 				}),
@@ -977,7 +996,8 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 					Response: &http.Response{
 						Body: io.NopCloser(
 							strings.NewReader(
-								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{}}`),
+								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{}}`,
+							),
 						),
 					},
 				}, nil,
@@ -994,7 +1014,8 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 					Response: &http.Response{
 						Body: io.NopCloser(
 							strings.NewReader(
-								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"}}`),
+								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"}}`,
+							),
 						),
 					},
 				}, nil,
@@ -1011,7 +1032,8 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 					Response: &http.Response{
 						Body: io.NopCloser(
 							strings.NewReader(
-								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"},"auth":{"client_token":"my-client-token"}}`),
+								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"},"auth":{"client_token":"my-client-token"}}`,
+							),
 						),
 					},
 				}, nil,
@@ -1029,7 +1051,8 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 			v := &Vault{
 				namespace: "test-namespace",
 				reader:    test.fakeLister,
-				issuer: gen.Issuer("vault-issuer",
+				issuer: gen.Issuer(
+					"vault-issuer",
 					gen.SetIssuerNamespace("namespace"),
 				),
 			}

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -200,7 +200,8 @@ func signedCertificateSecret(issuingCaPEM string, caPEM ...string) *certutil.Sec
 	// See https://github.com/hashicorp/vault/blob/v1.5.0/builtin/logical/pki/path_issue_sign.go#L256
 	// See https://github.com/hashicorp/vault/blob/v1.5.5/sdk/helper/certutil/types.go#L627
 	if len(caPEM) > 0 {
-		chain := []string{issuingCaPEM}
+		chain := make([]string, 0, 1+len(caPEM))
+		chain = append(chain, issuingCaPEM)
 		chain = append(chain, caPEM...)
 		secret.Data["ca_chain"] = chain
 	}


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
